### PR TITLE
[api]: Make calls sequential as Figma has agressive rate limiting in place now

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "prepare": "tsc"
   },
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "devDependencies": {

--- a/src/downloadSvgs.ts
+++ b/src/downloadSvgs.ts
@@ -44,19 +44,18 @@ const getDataFromConfig = async (
   });
 };
 
-const downloadSvgsData = (svgsData: SvgData[]): Promise<DownloadedSvgData[]> =>
-  Promise.all(
-    svgsData.map(
-      async (data): Promise<DownloadedSvgData> => {
-        const downloadedSvg = await fetch(data.url).then(r => r.text());
-
-        return {
-          data: downloadedSvg,
-          name: data.name
-        };
-      }
-    )
-  );
+const downloadSvgsData = async (svgsData: SvgData[]): Promise<DownloadedSvgData[]> => {
+  const batchSize = 100;
+  const downloadedSvgsData: DownloadedSvgData[] = [];
+  for (let i = 0; i < svgsData.length; i += batchSize) {
+    const data = await Promise.all(svgsData.slice(i, i + batchSize).map(svg => fetch(svg.url).then(async r => ({
+      data: await r.text(),
+      name: svg.name
+    }))));
+    downloadedSvgsData.push(...data);
+  }
+  return downloadedSvgsData;
+}
 
 const saveSvgsToFiles = async (
   downloadedSvgsData: DownloadedSvgData[],

--- a/src/getSvgs.ts
+++ b/src/getSvgs.ts
@@ -85,15 +85,16 @@ export default (client: FigmaClient) => async (
 
   const svgsIds = components.map(c => c.id)
   const batchCount = Math.ceil(svgsIds.length / batchSize);
-  const promises = Array.from(Array(batchCount), (_, i) => client.fileImages(config.fileId, {
-    format: "svg",
-    ids: svgsIds.slice(i * batchSize, (i + 1) * batchSize)
-  }))
 
-  const svgsData = (await Promise.all(promises)).flatMap((response, index) => {
-    const svgUrls = response.images;
-    return components.slice(index * batchSize, (index + 1) * batchSize).map(getSvgDataFromImageData(svgUrls))
-  })
+  const svgsData: SvgData[] = [];
+  for (let i = 0; i < batchCount; i++) {
+    const data = await client.fileImages(config.fileId, {
+      format: "svg",
+      ids: svgsIds.slice(i * batchSize, (i + 1) * batchSize)
+    })
+
+    svgsData.push(...components.slice(i * batchSize, (i + 1) * batchSize).map(getSvgDataFromImageData(data.images)))
+  }
 
   return { svgs: svgsData, lastModified: fileLastModified };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,13 @@ import getSvgs from "./getSvgs";
 import downloadSvgs from "./downloadSvgs";
 import FigmaClient from "./figmaClient";
 
-export default (token: string) => {
+export const figmaApiExporter = (token: string) => {
   const client = new FigmaClient({
-    personalAccessToken: token
+    personalAccessToken: token,
   });
 
   return {
     getSvgs: getSvgs(client),
-    downloadSvgs
+    downloadSvgs,
   };
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "ESNEXT" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
-    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+    "module": "es2015" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */


### PR DESCRIPTION
Previously we could fetch all the icon batches at once. Unfortunately this is triggering the rate limits now, so we need to back off and wait for `retry-after` when encountering rate limiting.

Additionally, we now make the requests sequentially to avoid hitting them.